### PR TITLE
Simplify valkyrie server uri

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -118,7 +118,14 @@ default['repose']['valkyrie_authorization']['enable_masking_403s'] = false
 default['repose']['valkyrie_authorization']['enable_bypass_account_admin'] = true
 default['repose']['valkyrie_authorization']['delegating_quality'] = nil
 default['repose']['valkyrie_authorization']['device_id_mismatch_action'] = 'keep'
-default['repose']['valkyrie_authorization']['valkyrie_server_uri'] = 'http://localhost:8900/valkyrie/v2.0'
+
+default['repose']['valkyrie_authorization']['valkyrie_server_uri'] = if node.chef_environment == 'prod'
+                                                                       'https://api.valkyrie.rackspace.com'
+                                                                     elsif node.chef_environment == 'stage'
+                                                                       'https://staging.api.valkyrie.rackspace.com'
+                                                                     else
+                                                                       'http://localhost:8900/valkyrie/v2.0'
+                                                                     end
 
 default['repose']['merge_header']['cluster_id'] = ['all']
 default['repose']['merge_header']['uri_regex'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -88,13 +88,9 @@ if %w(stage prod).include?(node.chef_environment)
 
   identity_url = URI.join(identity_url, '/').to_s # strip trailing path (repose adds it)
 
-  valkyrie_url = node.chef_environment == 'prod' ? 'https://api.valkyrie.rackspace.com' : 'https://staging.api.valkyrie.rackspace.com'
-
   node.set['repose']['keystone_v2']['identity_uri'] = identity_url
   node.set['repose']['keystone_v2']['identity_username'] = identity_username
   node.set['repose']['keystone_v2']['identity_password'] = identity_password
-
-  node.set['repose']['valkyrie_authorization']['valkyrie_server_uri'] = valkyrie_url
 
   # set non-default (environment-specific) configuration
 
@@ -119,7 +115,6 @@ if %w(stage prod).include?(node.chef_environment)
     root_path: '/',
     default: true
   }]
-
 end
 
 # NOTE these hash keys should be left as strings or system-model.cfg.xml.erb will break
@@ -184,3 +179,5 @@ remote_file "/usr/share/repose/filters/#{node['repose']['bundle_name']}" do
   mode '0755'
   action :create
 end
+
+node.save

--- a/recipes/filter-extract-device-id.rb
+++ b/recipes/filter-extract-device-id.rb
@@ -1,4 +1,4 @@
-include_recipe 'repose::install'
+include_recipe 'ele-repose::default'
 
 unless node['repose']['filters'].include? 'extract-device-id'
   filters = node['repose']['filters'] + ['extract-device-id']

--- a/recipes/filter-keystone-v2.rb
+++ b/recipes/filter-keystone-v2.rb
@@ -1,4 +1,4 @@
-include_recipe 'repose::install'
+include_recipe 'ele-repose::default'
 
 unless node['repose']['filters'].include? 'keystone-v2'
   filters = node['repose']['filters'] + ['keystone-v2']

--- a/recipes/filter-merge-header.rb
+++ b/recipes/filter-merge-header.rb
@@ -1,4 +1,4 @@
-include_recipe 'repose::install'
+include_recipe 'ele-repose::default'
 
 unless node['repose']['filters'].include? 'merge-header'
   filters = node['repose']['filters'] + ['merge-header']

--- a/recipes/filter-valkyrie-authorization.rb
+++ b/recipes/filter-valkyrie-authorization.rb
@@ -1,4 +1,4 @@
-include_recipe 'repose::install'
+include_recipe 'ele-repose::default'
 
 unless node['repose']['filters'].include? 'valkyrie-authorization'
   filters = node['repose']['filters'] + ['valkyrie-authorization']


### PR DESCRIPTION
The `valkyrie_server_uri` was not correctly being written in the valkyrie filter recipe.

- [x] sets correct `valkyrie_server_uri` in attributes for all environments
- [x] `node.save` to ensure `node.set` attributes are written to the server
- [x] change `repose::install` include to `ele-repose::default` in filters.
 * `ele-repose::default` itself includes `repose::install`
 * `::default` writes attributes that *must* be executed before the filter recipes can correctly run