### PR TITLE
don't call node.save in chef-solo

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -180,4 +180,6 @@ remote_file "/usr/share/repose/filters/#{node['repose']['bundle_name']}" do
   action :create
 end
 
-node.save
+unless Chef::Config[:solo]
+  node.save
+end


### PR DESCRIPTION
Unclear if we ever should call `node.save`, but certainly not in chef-solo, where it throws an error.