### PR TITLE
use the new ohai plugin networks*

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -94,14 +94,14 @@ if %w(stage prod).include?(node.chef_environment)
 
   # set non-default (environment-specific) configuration
 
-  node.set['repose']['extract_device_id']['maas_service_uri'] = "http://#{node['network']['ipaddress_eth0']}:7000"
+  node.set['repose']['extract_device_id']['maas_service_uri'] = "http://#{node['networks']['ipaddress_eth0']}:7000"
 
   # TODO: these next two attr updates would break a default len > 1 list of peers (should iterate and update ports?)
   # update for stage/prod port
   node.set['repose']['peers'] = [{
     cluster_id: 'repose',
     id: 'repose_node',
-    hostname: node['network']['ipaddress_eth0'],
+    hostname: node['networks']['ipaddress_eth0'],
     port: '8080'
   }]
 
@@ -110,7 +110,7 @@ if %w(stage prod).include?(node.chef_environment)
     cluster_id: 'repose',
     id: 'public_api',
     protocol: 'http',
-    hostname: node['network']['ipaddress_eth0'],
+    hostname: node['networks']['ipaddress_eth0'],
     port: '7000',
     root_path: '/',
     default: true


### PR DESCRIPTION
`ipaddress_eth0` is a magic value we generate in `chef.git`, which *used* to pollute the automatically-generated `network` namespace but [now populates networks](https://github.com/racker/chef/blob/master/site-cookbooks/ohai/files/default/plugins/networks.rb).