### PR TITLE
Increase public api connections

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,8 +31,8 @@ default['repose']['read_timeout'] = 600_000 # in millis
 
 default['repose']['connection_pool']['socket_timeout'] = 600_000 # in millis
 default['repose']['connection_pool']['connection_timeout'] = 30_000 # in millis
-default['repose']['connection_pool']['max_total'] = 1000
-default['repose']['connection_pool']['max_per_route'] = 500
+default['repose']['connection_pool']['max_total'] = 2000
+default['repose']['connection_pool']['max_per_route'] = 1000
 # https://repose.atlassian.net/wiki/display/REPOSE/HTTP+Connection+Pool+service
 default['repose']['connection_pool']['keepalive_timeout'] = 1 # disabled
 


### PR DESCRIPTION
I think we could go bigger, but lets start here.

The public_api should be able to accept way more connections than this.  AFAIK the reason to be cautious is that if we go too high, repose could have memory issues.

>Maximum number of connections that Repose opens across all endpoints. (If set too high, you might run out of memory.) Default is 400.