### PR TITLE
Bump api connections

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,8 +30,8 @@ default['repose']['endpoints'] = [{
 
 default['repose']['http_connection_pool']['socket_timeout'] = 300_000 # in millis
 default['repose']['http_connection_pool']['connection_timeout'] = 30_000 # in millis
-default['repose']['http_connection_pool']['max_total'] = 2000
-default['repose']['http_connection_pool']['max_per_route'] = 1000
+default['repose']['http_connection_pool']['max_total'] = 4000
+default['repose']['http_connection_pool']['max_per_route'] = 2000
 # https://repose.atlassian.net/wiki/display/REPOSE/HTTP+Connection+Pool+service
 default['repose']['http_connection_pool']['keepalive_timeout'] = 1 # disabled
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures ele-repose'
 long_description 'Installs/Configures ele-repose'
-version '0.5.1'
+version '0.5.2'
 
 issues_url 'https://github.com/mmi-cookbooks/ele-repose/issues'
 source_url 'https://github.com/mmi-cookbooks/ele-repose'


### PR DESCRIPTION
I've made this change manually in prod.

I'd still wanna bump it more since we should be able handle more, so I'll leave this as a placeholder while we tweak.
