### PR TITLE
Fix attribute name bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.5.7
+- fix bug in keystone_v2 attribute name
+
 # 0.5.6
 - add branch tests for lon or not lon DC for keystone attributes
 - add a chomp to remove v2.0 from the identity URI

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -100,7 +100,7 @@ default['repose']['extract_device_id']['delegating_quality'] = nil
 default['repose']['keystone_v2']['roles_in_header'] = true
 default['repose']['keystone_v2']['groups_in_header'] = false
 default['repose']['keystone_v2']['catalog_in_header'] = false
-default['repose']['keystone_v2']['whitelist'] = %w(
+default['repose']['keystone_v2']['white_list'] = %w(
   ^/?
   ^/pki/.*?
   ^/version?

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures ele-repose'
 long_description 'Installs/Configures ele-repose'
-version '0.5.6'
+version '0.5.7'
 
 issues_url 'https://github.com/mmi-cookbooks/ele-repose/issues'
 source_url 'https://github.com/mmi-cookbooks/ele-repose'

--- a/test/integration/default/serverspec/filter-keystone-v2_spec.rb
+++ b/test/integration/default/serverspec/filter-keystone-v2_spec.rb
@@ -10,4 +10,5 @@ describe file('/etc/repose/keystone-v2.cfg.xml') do
   it { should be_grouped_into 'repose' }
   it { should be_mode 640 }
   its(:content) { should_not match %r{/v2.0} }
+  its(:content) { should match %r{white_list} }
 end

--- a/test/integration/default/serverspec/filter-keystone-v2_spec.rb
+++ b/test/integration/default/serverspec/filter-keystone-v2_spec.rb
@@ -10,5 +10,5 @@ describe file('/etc/repose/keystone-v2.cfg.xml') do
   it { should be_grouped_into 'repose' }
   it { should be_mode 640 }
   its(:content) { should_not match %r{/v2.0} }
-  its(:content) { should match %r{white_list} }
+  its(:content) { should match %r{white-list} }
 end

--- a/test/integration/stage_dfw1_keystone/serverspec/filter-keystone-v2_spec.rb
+++ b/test/integration/stage_dfw1_keystone/serverspec/filter-keystone-v2_spec.rb
@@ -16,4 +16,5 @@ describe file('/etc/repose/keystone-v2.cfg.xml') do
   its(:content) { should_not match %r{username="uk-admin"} }
   its(:content) { should match %r{password="uspass"} }
   its(:content) { should_not match %r{password="ukpass"} }
+  its(:content) { should match %r{white_list} }
 end

--- a/test/integration/stage_dfw1_keystone/serverspec/filter-keystone-v2_spec.rb
+++ b/test/integration/stage_dfw1_keystone/serverspec/filter-keystone-v2_spec.rb
@@ -16,5 +16,5 @@ describe file('/etc/repose/keystone-v2.cfg.xml') do
   its(:content) { should_not match %r{username="uk-admin"} }
   its(:content) { should match %r{password="uspass"} }
   its(:content) { should_not match %r{password="ukpass"} }
-  its(:content) { should match %r{white_list} }
+  its(:content) { should match %r{white-list} }
 end

--- a/test/integration/stage_lon3_keystone/serverspec/filter-keystone-v2_spec.rb
+++ b/test/integration/stage_lon3_keystone/serverspec/filter-keystone-v2_spec.rb
@@ -16,5 +16,5 @@ describe file('/etc/repose/keystone-v2.cfg.xml') do
   its(:content) { should match %r{username="uk-admin"} }
   its(:content) { should_not match %r{password="uspass"} }
   its(:content) { should match %r{password="ukpass"} }
-  its(:content) { should match %r{white_list} }
+  its(:content) { should match %r{white-list} }
 end

--- a/test/integration/stage_lon3_keystone/serverspec/filter-keystone-v2_spec.rb
+++ b/test/integration/stage_lon3_keystone/serverspec/filter-keystone-v2_spec.rb
@@ -16,4 +16,5 @@ describe file('/etc/repose/keystone-v2.cfg.xml') do
   its(:content) { should match %r{username="uk-admin"} }
   its(:content) { should_not match %r{password="uspass"} }
   its(:content) { should match %r{password="ukpass"} }
+  its(:content) { should match %r{white_list} }
 end


### PR DESCRIPTION
# Description
For keystone_v2 namespace, the attribute name is white_list.
Bump version to 0.5.7.