### PR TITLE
We can delete these two attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -98,8 +98,6 @@ default['repose']['extract_device_id']['cache_timeout_millis'] = 60000
 default['repose']['extract_device_id']['delegating_quality'] = nil
 
 default['repose']['keystone_v2']['roles_in_header'] = true
-default['repose']['keystone_v2']['groups_in_header'] = false
-default['repose']['keystone_v2']['catalog_in_header'] = false
 default['repose']['keystone_v2']['white_list'] = %w(
   ^/?
   ^/pki/.*?


### PR DESCRIPTION
They default to nil, which should have the same effect as false.  The upstream cookbook only adds the XML container if the boolean is set.  So they should disappear as empty containers for ele after this gets rolled up in a next release of this wrapper.