### PR TITLE
Fixes to get header-normalization and header-translation working

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,14 +24,6 @@ suites:
     - apt
     - java
     - recipe[ele-repose::default]
-    - recipe[ele-repose::filter-keystone-v2]
-    - recipe[ele-repose::filter-extract-device-id]
-    - recipe[ele-repose::filter-valkyrie-authorization]
-    - recipe[repose::filter-slf4j-http-logging]
-    - recipe[repose::filter-header-normalization]
-    - recipe[repose::filter-header-translation]
-    - recipe[repose::service-http-connection-pool]
-    - recipe[repose::service-dist-datastore]
   attributes:
     repose:
       client_auth:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.9
+- add header-normalization and header-translation to be explicitly called from ele-repose::default
+- add basic integration tests to check for some content in header translation and normalization config files
+
 # 0.5.8
 - add integration tests for extract-device-id uri issue
 - add cachier to kitchen driver to see if that can speed up local testing

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,10 @@ default['repose']['endpoints'] = [{
   default: true
 }]
 
+default['repose']['services'] = %w(
+  http-connection-pool
+)
+
 default['repose']['http_connection_pool']['socket_timeout'] = 300_000 # in millis
 default['repose']['http_connection_pool']['connection_timeout'] = 30_000 # in millis
 default['repose']['http_connection_pool']['max_total'] = 4000

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures ele-repose'
 long_description 'Installs/Configures ele-repose'
-version '0.5.8'
+version '0.5.9'
 
 issues_url 'https://github.com/mmi-cookbooks/ele-repose/issues'
 source_url 'https://github.com/mmi-cookbooks/ele-repose'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,6 +12,9 @@ java_ark 'jdk' do
 end
 
 include_recipe 'repose::install'
+include_recipe 'repose::filter-header-normalization'
+include_recipe 'repose::filter-header-translation'
+include_recipe 'ele-repose::filter-keystone-v2'
 include_recipe 'ele-repose::filter-merge-header'
 include_recipe 'ele-repose::filter-valkyrie-authorization'
 
@@ -55,8 +58,7 @@ directory node['repose']['config_directory'] do
   mode '0755'
 end
 
-services = node['repose']['services'].reject { |x| x == 'connection-pool' }
-
+services = node['repose']['services'].reject { |x| x == 'http-connection-pool' }
 node['repose']['services'].each do |service|
   include_recipe "repose::service-#{service}"
 end
@@ -114,7 +116,7 @@ template "#{node['repose']['config_directory']}/system-model.cfg.xml" do
     rewrite_host_header: node['repose']['rewrite_host_header'],
     nodes: node['repose']['peers'],
     services: services,
-    service_cluster_map: { 'dist-datastore' => node['repose']['dist_datastore']['cluster_id'] },
+    service_cluster_map: { 'http-connection-pool' => node['repose']['http_connection_pool']['cluster_id'] },
     filters: node['repose']['filters'],
     filter_cluster_map: filter_cluster_map,
     filter_uri_regex_map: filter_uri_regex_map,

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -25,6 +25,30 @@ describe file('/etc/repose/container.cfg.xml') do
   it { should be_mode 640 }
 end
 
+describe file('/etc/repose/http-connection-pool.cfg.xml') do
+  it { should be_file }
+  it { should be_owned_by 'repose' }
+  it { should be_grouped_into 'repose' }
+  it { should be_mode 644 }
+  its(:content) { should contain %r{http.conn-manager.max-total="4000"} }
+end
+
+describe file('/etc/repose/header-normalization.cfg.xml') do
+  it { should be_file }
+  it { should be_owned_by 'repose' }
+  it { should be_grouped_into 'repose' }
+  it { should be_mode 644 }
+  its(:content) { should contain %r{header id="X-Authorization"\/} }
+end
+
+describe file('/etc/repose/header-translation.cfg.xml') do
+  it { should be_file }
+  it { should be_owned_by 'repose' }
+  it { should be_grouped_into 'repose' }
+  it { should be_mode 644 }
+  its(:content) { should contain %r{new-name="X-Repose-Forwarded-Host"} }
+end
+
 describe service('repose-valve') do
   it { should be_enabled }
   # TODO: This doesn't work under kitchen-docker-travis, figure out why to re-enable


### PR DESCRIPTION
# Description
@jjbuchan noticed that the header-translation file wasn't being written out.  It needed to be called explicitly in the default recipe.  Added some integration tests to check that it is being written out and cross checks a line of content.

# Todo 
Tag a release, bump in racker/chef and remove the recipes in the ele-repose role that are already being explicitly called from the default recipe in ele-repose wrapper cookbook.