### PR TITLE
set default keystone_v2, allow environments to override

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
@@ -15,7 +16,7 @@ namespace :style do
 end
 
 desc 'Run all style checks'
-task style: %w(style:chef style:ruby)
+task style: %w[style:chef style:ruby]
 
 task :unit do
   sh "bundle exec 'rspec ./test/unit/spec/ --color --format documentation'"
@@ -43,6 +44,6 @@ namespace :integration do
 end
 
 desc 'Run all tests'
-task test: %w(style unit integration)
+task test: %w[style unit integration]
 
-task default: %w(style unit integration)
+task default: %w[style unit integration]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,6 +101,7 @@ default['repose']['extract_device_id']['maas_service_uri'] = 'http://localhost:3
 default['repose']['extract_device_id']['cache_timeout_millis'] = 60000
 default['repose']['extract_device_id']['delegating_quality'] = nil
 
+default['repose']['keystone_v2']['uri'] = 'http://localhost:8900/identity'
 default['repose']['keystone_v2']['roles_in_header'] = true
 default['repose']['keystone_v2']['white_list'] = %w(
   ^/?

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,14 +9,14 @@ default['repose']['peers'] = [{
   port: '13579'
 }]
 
-default['repose']['filters'] = %w(
+default['repose']['filters'] = %w[
   header-normalization
   header-translation
   keystone-v2
   extract-device-id
   valkyrie-authorization
   merge-header
-)
+]
 
 default['repose']['endpoints'] = [{
   cluster_id: 'repose',
@@ -28,9 +28,9 @@ default['repose']['endpoints'] = [{
   default: true
 }]
 
-default['repose']['services'] = %w(
+default['repose']['services'] = %w[
   http-connection-pool
-)
+]
 
 default['repose']['http_connection_pool']['socket_timeout'] = 300_000 # in millis
 default['repose']['http_connection_pool']['connection_timeout'] = 30_000 # in millis
@@ -55,7 +55,7 @@ default['repose']['header_normalization']['whitelist'] = []
 default['repose']['header_normalization']['blacklist'] = [{
   id: 'authorization',
   http_methods: 'ALL',
-  headers: %w(
+  headers: %w[
     X-Authorization
     X-Token-Expires
     X-Identity-Status
@@ -73,7 +73,7 @@ default['repose']['header_normalization']['blacklist'] = [{
     X-Subject-Token
     X-Subject-Name
     X-Subject-ID
-  )
+  ]
 }]
 
 default['repose']['version'] = '8.0.1.0'
@@ -140,4 +140,4 @@ normal['repose']['valkyrie_authorization']['valkyrie_server_uri'] = if node.chef
 
 default['repose']['merge_header']['cluster_id'] = ['all']
 default['repose']['merge_header']['uri_regex'] = nil
-default['repose']['merge_header']['headers'] = %w(X-Roles X-Impersonator-Roles)
+default['repose']['merge_header']['headers'] = %w[X-Roles X-Impersonator-Roles]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,7 +41,7 @@ end
 
 service 'repose-valve' do
   supports restart: true, status: true
-  action [:enable, :start]
+  action %i[enable start]
   provider Chef::Provider::Service::Upstart
 end
 
@@ -63,7 +63,7 @@ node['repose']['services'].each do |service|
   include_recipe "repose::service-#{service}"
 end
 
-if %w(stage prod).include?(node.chef_environment)
+if %w[stage prod].include?(node.chef_environment)
   # set non-default (environment-specific) configuration
   node.default['repose']['extract_device_id']['maas_service_uri'] = "http://#{node['networks']['ipaddress_eth0']}:7000"
 

--- a/recipes/filter-keystone-v2.rb
+++ b/recipes/filter-keystone-v2.rb
@@ -23,8 +23,4 @@ if %w(stage prod _default).include?(node.chef_environment)
   node.default['repose']['keystone_v2']['password_admin'] = identity_password
 end
 
-if %w(dev).include?(node.chef_environment)
-  node.override['repose']['keystone_v2']['uri'] = 'http://localhost:8900/identity'
-end
-
 include_recipe 'repose::filter-keystone-v2'

--- a/recipes/filter-keystone-v2.rb
+++ b/recipes/filter-keystone-v2.rb
@@ -1,6 +1,6 @@
 include_recipe 'ele-repose::default'
 
-if %w(stage prod _default).include?(node.chef_environment)
+if %w[stage prod _default].include?(node.chef_environment)
   # load non-default secrets
   ele_credentials = Chef::EncryptedDataBagItem.load('passwords', 'ele')
 

--- a/test/integration/default/serverspec/custom-filter-bundle_spec.rb
+++ b/test/integration/default/serverspec/custom-filter-bundle_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/integration/default/serverspec/filter-extract-device-id_spec.rb
+++ b/test/integration/default/serverspec/filter-extract-device-id_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/integration/default/serverspec/filter-keystone-v2_spec.rb
+++ b/test/integration/default/serverspec/filter-keystone-v2_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/integration/default/serverspec/filter-merge-header_spec.rb
+++ b/test/integration/default/serverspec/filter-merge-header_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/integration/default/serverspec/filter-valkyrie-authorization_spec.rb
+++ b/test/integration/default/serverspec/filter-valkyrie-authorization_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/integration/stage_dfw1_extract-device-id/serverspec/default_spec.rb
+++ b/test/integration/stage_dfw1_extract-device-id/serverspec/default_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/integration/stage_dfw1_extract-device-id/serverspec/filter-extract-device-id_spec.rb
+++ b/test/integration/stage_dfw1_extract-device-id/serverspec/filter-extract-device-id_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/integration/stage_dfw1_keystone/serverspec/default_spec.rb
+++ b/test/integration/stage_dfw1_keystone/serverspec/default_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/integration/stage_dfw1_keystone/serverspec/filter-keystone-v2_spec.rb
+++ b/test/integration/stage_dfw1_keystone/serverspec/filter-keystone-v2_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/integration/stage_lon3_keystone/serverspec/default_spec.rb
+++ b/test/integration/stage_lon3_keystone/serverspec/default_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/integration/stage_lon3_keystone/serverspec/filter-keystone-v2_spec.rb
+++ b/test/integration/stage_lon3_keystone/serverspec/filter-keystone-v2_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # License:: Apache License, Version 2.0
 #
 

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 


### PR DESCRIPTION
fixes https://github.com/racker/chef/issues/4549

# What

We special-case defaults for `dev`, but this breaks for other environments that aren't "real" (`aux`, `test`, etc) that need dev-like values.

# Again?!

see https://github.com/racker/sfo-devops/issues/132