### PR TITLE
Add an execute block to check for deb package hold

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -149,3 +149,13 @@ remote_file "/usr/share/repose/filters/#{node['repose']['bundle_name']}" do
 end
 
 include_recipe 'ele-repose::filter-extract-device-id'
+
+# put a hold on the repose deb packages
+repose_pkgs = %w[repose-extensions-filter-bundle repose-filter-bundle repose-valve]
+repose_pkgs.each do |pkg|
+  execute "hold #{pkg}" do
+    command "echo '#{pkg} hold' | sudo dpkg --set-selections"
+    not_if "dpkg --get-selections | grep #{pkg} | grep hold"
+    action :run
+  end
+end


### PR DESCRIPTION
# Description
We want to set the repose packages to be held so that they are not accidentally upgraded if someone runs an apt-get update/upgrade cycle.

# How 
Add some logic at bottom of default recipe to check if packages are held, if not, then execute an action to set them to hold status.

# Todo
Long term all packages should possibly be managed by chef and/or we never run apt-get update/upgrade because nodes or containers are rebuilt regularly.  That won't happen short term so some packages need to be watched and held.